### PR TITLE
Update list_field.dart to only updateField on valid values

### DIFF
--- a/packages/widgetbook/lib/src/fields/list_field.dart
+++ b/packages/widgetbook/lib/src/fields/list_field.dart
@@ -38,7 +38,11 @@ class ListField<T> extends Field<T> {
       trailingIcon: const Icon(Icons.keyboard_arrow_down_rounded),
       selectedTrailingIcon: const Icon(Icons.keyboard_arrow_up_rounded),
       initialSelection: value ?? values.first,
-      onSelected: (value) => updateField(context, group, value!),
+      onSelected: (value) {
+        if (value != null) {
+          updateField(context, group, value);
+        }
+      },
       dropdownMenuEntries: values
           .map(
             (value) => DropdownMenuEntry(


### PR DESCRIPTION
The DropdownMenu has search enabled, which allows users to type any input. If the user types something that doesn't match an existing item, `value` is null, leading to a null pointer issue.

Instead just don't update the field when null is provided.

### List of issues which are fixed by the PR

Fixes https://github.com/widgetbook/widgetbook/issues/1151

### Checklist

- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[CLA]: https://docs.google.com/forms/d/e/1FAIpQLScuRfjUzENsLsmQgqZlGLxMKbFi7zuXoPARyXytoyQrq7ntUw/viewform
[Discord]: https://discord.com/invite/zT4AMStAJA
